### PR TITLE
interface.h/cpp: change function names according to used classes

### DIFF
--- a/source/interface.cpp
+++ b/source/interface.cpp
@@ -194,30 +194,30 @@ void widgetSetFixedSize(void* widget, int width, int height) {
     _widget->setFixedSize(width, height);
 }
 
-void windowSetWindowTitle(void* window, char* title) {
-    QWidget *_window = reinterpret_cast<QWidget*>(window);
-    _window->setWindowTitle(title);
+void widgetSetWindowTitle(void* widget, char* title) {
+    QWidget *_widget = reinterpret_cast<QWidget*>(widget);
+    _widget->setWindowTitle(title);
 }
 
-int windowIsActiveWindow(void* window) {
-    QWidget *_window = reinterpret_cast<QWidget*>(window);
-    return _window->isActiveWindow();
+int widgetIsActiveWindow(void* widget) {
+    QWidget *_widget = reinterpret_cast<QWidget*>(widget);
+    return _widget->isActiveWindow();
 }
 
-void windowShowFullScreen(void* window) {
-    QWidget *_window = reinterpret_cast<QWidget*>(window);
-    _window->showFullScreen();
+void widgetShowFullScreen(void* widget) {
+    QWidget *_widget = reinterpret_cast<QWidget*>(widget);
+    _widget->showFullScreen();
 }
 
-void windowShowNormal(void* window) {
-    QWidget *_window = reinterpret_cast<QWidget*>(window);
-    _window->showNormal();
+void widgetShowNormal(void* widget) {
+    QWidget *_widget = reinterpret_cast<QWidget*>(widget);
+    _widget->showNormal();
 }
 
-void windowPresent(void* window) {
-    QWidget *_window = reinterpret_cast<QWidget*>(window);
-    _window->show();
-    _window->raise();
+void widgetPresent(void* widget) {
+    QWidget *_widget = reinterpret_cast<QWidget*>(widget);
+    _widget->show();
+    _widget->raise();
 }
 
 void layoutSetContentsMargins(void* layout, int left, int top, int right, int bottom) {

--- a/source/interface.h
+++ b/source/interface.h
@@ -20,7 +20,7 @@ typedef void (*fpKeyPress)(int id, int keyCode, char* keyString, int modifierFla
 
 EXTERNC void* newKeyPressFilter(int id, fpKeyPress callback);
 EXTERNC void widgetInstallKeyPressFilter(void* widget, void* keyPressFilter);
-EXTERNC int windowIsActiveWindow(void* window);
+EXTERNC int widgetIsActiveWindow(void* widget);
 EXTERNC QApplication* newQApplication(int argc, char** argv);
 EXTERNC void* newLoadFinishedListener(int id, fpInt callback);
 EXTERNC void loadFinishedListenerConnect(void* loadStartedListener, void* webEngineView);
@@ -48,10 +48,10 @@ EXTERNC void widgetDelete(void* object);
 EXTERNC void widgetResize(void* widget, int width, int height);
 EXTERNC void widgetSetFixedHeight(void* widget, int height);
 EXTERNC void widgetSetFixedSize(void* widget, int width, int height);
-EXTERNC void windowSetWindowTitle(void* window, char* title);
-EXTERNC void windowShowFullScreen(void* window);
-EXTERNC void windowShowNormal(void* window);
-EXTERNC void windowPresent(void* window);
+EXTERNC void widgetSetWindowTitle(void* widget, char* title);
+EXTERNC void widgetShowFullScreen(void* widget);
+EXTERNC void widgetShowNormal(void* widget);
+EXTERNC void widgetPresent(void* widget);
 EXTERNC void layoutSetContentsMargins(void* layout, int left, int top, int right, int bottom);
 EXTERNC void layoutSetSpacing(void* layout, int spacing);
 EXTERNC void layoutInsertWidget(void* layout, int index, void* widget);

--- a/source/interface.lisp
+++ b/source/interface.lisp
@@ -226,29 +226,29 @@
   (height :int))
 (export 'widget-set-fixed-size)
 
-(defcfun ("windowSetWindowTitle" window-set-window-title) :void
-  (window :pointer)
+(defcfun ("widgetSetWindowTitle" widget-set-window-title) :void
+  (widget :pointer)
   (title :string))
-(export 'window-set-window-title)
+(export 'widget-set-window-title)
 
-(defcfun ("windowShowFullScreen" window-show-full-screen) :void
-  (window :pointer))
-(export 'window-show-full-screen)
+(defcfun ("widgetShowFullScreen" widget-show-full-screen) :void
+  (widget :pointer))
+(export 'widget-show-full-screen)
 
-(defcfun ("windowShowNormal" window-show-normal) :void
-  (window :pointer))
-(export 'window-show-normal)
+(defcfun ("widgetShowNormal" widget-show-normal) :void
+  (widget :pointer))
+(export 'widget-show-normal)
 
-(defcfun ("windowPresent" window-present) :void
-  (window :pointer))
-(export 'window-present)
+(defcfun ("widgetPresent" widget-present) :void
+  (widget :pointer))
+(export 'widget-present)
 
-(defcfun ("windowIsActiveWindow" %window-is-active-window) :int
-  (window :pointer))
+(defcfun ("widgetIsActiveWindow" %widget-is-active-window) :int
+  (widget :pointer))
 
-(defun window-is-active-window (window)
-  (if (> (%window-is-active-window window) 0) t nil))
-(export 'window-is-active-window)
+(defun widget-is-active-window (widget)
+  (if (> (%widget-is-active-window widget) 0) t nil))
+(export 'widget-is-active-window)
 
 (defcfun ("layoutSetContentsMargins" layout-set-contents-margins) :void
   (layout :pointer)


### PR DESCRIPTION
This fixes ambiguity in function names by renaming them according to wrapped classes.

#### Motivation

Some wrapper function names do not describe Qt objects inside them.

The example below shows a function with a name starting from "window" but using an instance of `QWidget` class:
``` cpp
void windowSetWindowTitle(void* window, char* title) {
    QWidget *_window = reinterpret_cast<QWidget*>(window);
    _window->setWindowTitle(title);
}
```

The change of function names now helps avoid ambiguity later, for example, in implementing wrapper functions for methods of `QWindow` class.