### PR TITLE
Use void pointers instead of C++ object pointers.

### DIFF
--- a/source/interface.cpp
+++ b/source/interface.cpp
@@ -7,6 +7,10 @@ void* newKeyPressFilter(int id, fpKeyPress callback) {
     return keyPressFilter;
 }
 
+void* newEmptyKeyPressFilter () {
+    return (void*) new KeyPressFilter();
+}
+
 void widgetInstallKeyPressFilter(void* widget, void* keyPressFilter) {
     KeyPressFilter *_keyPressFilter = reinterpret_cast<KeyPressFilter*>(keyPressFilter);
     QWidget *_widget = reinterpret_cast<QWidget*>(widget);
@@ -76,8 +80,8 @@ void LoadStartedListener::loadStarted() {
     return;
 }
 
-QApplication* newQApplication(int argc, char** argv) {
-    return new QApplication(argc, argv);
+void* newQApplication(int argc, char** argv) {
+    return (void*) new QApplication(argc, argv);
 }
 
 int applicationExec(void* application) {
@@ -91,34 +95,34 @@ void applicationQuit(void* application) {
     return;
 }
 
-QWidget* newQWidget() {
+void* newQWidget() {
     QWidget *widget = new QWidget;
-    return widget;
+    return (void*) widget;
 }
 
-QWindow* newQWindow() {
+void* newQWindow() {
     QWindow *window = new QWindow;
-    return window;
+    return (void*) window;
 }
 
-QVBoxLayout* newQVBoxLayout() {
+void* newQVBoxLayout() {
     QVBoxLayout *layout = new QVBoxLayout;
-    return layout;
+    return (void*) layout;
 }
 
-QHBoxLayout* newQHBoxLayout() {
+void* newQHBoxLayout() {
     QHBoxLayout *layout = new QHBoxLayout;
-    return layout;
+    return (void*) layout;
 }
 
-QPushButton* newQPushButton(char* label){
+void* newQPushButton(char* label){
     QPushButton *pushButton = new QPushButton(label);
-    return pushButton;
+    return (void*) pushButton;
 }
 
-QWebEngineView* newQWebEngineView() {
+void* newQWebEngineView() {
     QWebEngineView *webEngineView = new QWebEngineView();
-    return webEngineView;
+    return (void*) webEngineView;
 }
 
 void webEngineViewLoad(void* webEngineView, char* url) {
@@ -263,15 +267,15 @@ void layoutInsertWidget(void* layout, int index, void* widget) {
 }
 
 int main (int argc, char** argv) {
-    QApplication* app = new QApplication(argc, argv);
-    QWidget *window = reinterpret_cast<QWidget*>(newQWidget());
-    QVBoxLayout *layout = reinterpret_cast<QVBoxLayout*>(newQVBoxLayout());
-    QWebEngineView *web = reinterpret_cast<QWebEngineView*>(newQWebEngineView());
-    KeyPressFilter *keyPressFilter = new KeyPressFilter();
+    void *app = newQApplication(argc, argv);
+    void *window = newQWidget();
+    void *layout = newQVBoxLayout();
+    void *web = newQWebEngineView();
+    void *keyPressFilter = newEmptyKeyPressFilter();
     webEngineViewLoad(web, (char*)"https://www.duckduckgo.com");
     layoutAddWidget(layout, web);
     widgetSetLayout(window, layout);
     widgetShow(window);
-    window->installEventFilter(keyPressFilter);
-    return app->exec();
+    widgetInstallKeyPressFilter(window, keyPressFilter);
+    return applicationExec(app);
 }

--- a/source/interface.h
+++ b/source/interface.h
@@ -20,21 +20,22 @@ typedef void (*fpKeyPress)(int id, int keyCode, char* keyString, int modifierFla
 #endif
 
 EXTERNC void* newKeyPressFilter(int id, fpKeyPress callback);
+EXTERNC void* newEmptyKeyPressFilter();
 EXTERNC void widgetInstallKeyPressFilter(void* widget, void* keyPressFilter);
 EXTERNC int widgetIsActiveWindow(void* widget);
-EXTERNC QApplication* newQApplication(int argc, char** argv);
+EXTERNC void* newQApplication(int argc, char** argv);
 EXTERNC void* newLoadFinishedListener(int id, fpInt callback);
 EXTERNC void loadFinishedListenerConnect(void* loadStartedListener, void* webEngineView);
 EXTERNC void* newLoadStartedListener(int id, fpInt callback);
 EXTERNC void loadStartedListenerConnect(void* loadStartedListener, void* webEngineView);
 EXTERNC int applicationExec(void* application);
 EXTERNC void applicationQuit(void* application);
-EXTERNC QPushButton* newQPushButton(char* label);
-EXTERNC QWindow* newQWindow();
-EXTERNC QWidget* newQWidget();
-EXTERNC QHBoxLayout* newQHBoxLayout();
-EXTERNC QVBoxLayout* newQVBoxLayout();
-EXTERNC QWebEngineView* newQWebEngineView();
+EXTERNC void* newQPushButton(char* label);
+EXTERNC void* newQWindow();
+EXTERNC void* newQWidget();
+EXTERNC void* newQHBoxLayout();
+EXTERNC void* newQVBoxLayout();
+EXTERNC void* newQWebEngineView();
 EXTERNC char* webEngineViewUrl(void* webEngineView);
 EXTERNC void webEngineViewLoad(void* webEngineView, char* url);
 EXTERNC void* webEngineViewPage(void* webEngineView);

--- a/source/interface.lisp
+++ b/source/interface.lisp
@@ -50,6 +50,9 @@
   (callback :pointer))
 (export 'new-key-press-filter)
 
+(defcfun ("newEmptyKeyPressFilter" new-empty-key-press-filter) :pointer)
+(export 'new-empty-key-press-filter)
+
 (defcfun ("widgetInstallKeyPressFilter" %widget-install-key-press-filter) :pointer
   (widget :pointer)
   (key-press-filter :pointer))


### PR DESCRIPTION
This uses `void *` instead of QWhatever pointers in function return types. This is consistent with how we treat C++ objects -- as opaque pointers -- and will probably cause less errors on the side of the testing/application C/Lisp code.

All the C++ idioms in `main()` of `interface.cpp` are replaced with equivalent C code. This required writing a new function (`newEmptyKeyPressFilter()`, namely). Should there be a Lisp binding for it? Doesn't look really useful.

It's fully compatible with the existing Lisp-side code. Compiles, runs (I was able to test the C version only, so not sure about the CL one).

How does it look to you?