### PR TITLE
Add widget-show-maximized function

### DIFF
--- a/source/interface.cpp
+++ b/source/interface.cpp
@@ -282,6 +282,11 @@ void widgetShowFullScreen(void* widget) {
     _widget->showFullScreen();
 }
 
+void widgetShowMaximized(void* widget) {
+    QWidget *_widget = reinterpret_cast<QWidget*>(widget);
+    _widget->showMaximized();
+}
+
 void widgetShowNormal(void* widget) {
     QWidget *_widget = reinterpret_cast<QWidget*>(widget);
     _widget->showNormal();

--- a/source/interface.h
+++ b/source/interface.h
@@ -65,6 +65,7 @@ EXTERNC void widgetSetFixedHeight(void* widget, int height);
 EXTERNC void widgetSetFixedSize(void* widget, int width, int height);
 EXTERNC void widgetSetWindowTitle(void* widget, char* title);
 EXTERNC void widgetShowFullScreen(void* widget);
+EXTERNC void widgetShowMaximized(void* widget);
 EXTERNC void widgetShowNormal(void* widget);
 EXTERNC void widgetPresent(void* widget);
 EXTERNC void layoutSetContentsMargins(void* layout, int left, int top, int right, int bottom);

--- a/source/interface.lisp
+++ b/source/interface.lisp
@@ -301,6 +301,10 @@
   (widget :pointer))
 (export 'widget-show-full-screen)
 
+(defcfun ("widgetShowMaximized" widget-show-maximized) :void
+  (widget :pointer))
+(export 'widget-show-maximized)
+
 (defcfun ("widgetShowNormal" widget-show-normal) :void
   (widget :pointer))
 (export 'widget-show-normal)


### PR DESCRIPTION
This exposes QTWebEngine's widgetShowMaximized function to Common Lisp
as widget-show-maximized.

This change is necessary to support maximizing the Nyxt's QT window from Common Lisp, such as with the toggle-maximize command for which I plan to open a pull request in the Nyxt repo.